### PR TITLE
Add musl configuration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,7 @@ jobs:
           distribution: 'liberica'
           java-version: ${{ matrix.graalvm-version }}
           cache: 'maven'
+          native-image-musl: true
 
       - name: GraalVM Compile
         run: ./mvnw clean -Pnative native:compile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
 
       - uses: graalvm/setup-graalvm@v1
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,12 @@
             <plugin>
                 <groupId>org.graalvm.buildtools</groupId>
                 <artifactId>native-maven-plugin</artifactId>
+                <configuration>
+                    <buildArgs>
+                        <buildArg>--static</buildArg>
+                        <buildArg>--libc=musl</buildArg>
+                    </buildArgs>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Hopefully fixes #7 and make the bin more portable (no hard libc dependency)

See for reference : https://github.com/oracle/graal/issues/8911